### PR TITLE
taf.library: return to original wd on exit

### DIFF
--- a/R/taf.library.R
+++ b/R/taf.library.R
@@ -64,7 +64,7 @@ taf.library <- function(package, messages=FALSE, warnings=FALSE)
   ## Add bootstrap/library to lib path, using that rather than external library
   opath <- .libPaths()
   .libPaths(c("bootstrap/library", opath))
-  on.exit(.libPaths(opath))
+  on.exit(.libPaths(opath), add = TRUE)
 
   supM <- if(messages) identity else suppressMessages
   supW <- if(warnings) identity else suppressWarnings


### PR DESCRIPTION
There is a bug in `taf.library` that affects calls of the function from the bootstrap.

As it was, the code in the second ´on.exit´ replaces that of the first one. ´add = TRUE´ in the second one fixes the issue.